### PR TITLE
Update properties.dart

### DIFF
--- a/lib/properties.dart
+++ b/lib/properties.dart
@@ -32,9 +32,14 @@ class PropertiesScreen extends StatelessWidget {
                   child: Text(key),
                 ),
                 Expanded(
-                  flex: 1,
-                  child: Text(value.toString()),
-                )
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Text(
+                      value.toString(),
+                      overflow: TextOverflow.visible,
+                    ),
+                  ),
+                ),
               ]
             ),
           );


### PR DESCRIPTION
If the string is too long (only short sentences are possible right now) the string is truncated, so not all text is displayed. 

With this proposed change the following will happen: if the value.toString() is longer than the available space, the text will be horizontally scrollable within the Container. If the text fits within the available space, it will be displayed normally without any scrolling.