### PR TITLE
Fix for a depreciation warning from pyproj

### DIFF
--- a/python/fieldlogger.py
+++ b/python/fieldlogger.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from pyproj import Proj, transform
+from pyproj import Proj, transform, CRS
 import os
 import ftplib
 
@@ -98,7 +98,7 @@ def read_locations(fname, out=None):
 
 def rd2wgs(x, y):
     """Calculate longitude and latitude from x and y in rd-coordinates"""
-    lon, lat = transform(Proj(init="epsg:28992"), Proj(init="epsg:4326"), x, y)
+    lat, lon = transform(Proj(CRS("epsg:28992")), Proj(CRS("epsg:4326")), x, y)
     return lon, lat
 
 


### PR DESCRIPTION
The +init=<auth>:<auth_code> syntax is deprecated and will be removed in future versions of PROJ. See: https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6

Suggested fix.