### PR TITLE
Change position of 'write' statement

### DIFF
--- a/python/fieldform.py
+++ b/python/fieldform.py
@@ -129,9 +129,10 @@ def location_file_from_fieldlogger(fname_csv, fname_json, return_data=False):
             locations[location["NAME"]]["sublocations"][id] = subloc
         data["locations"] = locations
 
+    # %% write dictionary to json
+    write_location_file(data, fname_json)
+
     # %% return data if requested
     if return_data:
         return data
 
-    # %% write dictionary to json
-    write_location_file(data, fname_json)


### PR DESCRIPTION
Whe return_data=True, the 'return' statement would be executed and the 'write' statement skipped. So the 'write' statement should come before the 'return'.